### PR TITLE
Change example application to be a simple WAI application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 *.sw[op]
-/example/.cabal-sandbox/
-/example/cabal.sandbox.config
-/example/dist
+.stack-work
+/example/build

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ ENTRYPOINT ["/usr/bin/hello"]
 A project must include the following files:
 
 ```.
-├── project.cabal
-├── Setup.hs
+├── Dockerfile
+├── example.cabal
+├── stack.yaml
 └── ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ docker run \
   hello
 
 # Run the binary inside the docker container
-docker run -it --rm hello:latest
+docker run -it -p 3000:3000 --rm hello:latest
 ```
 
 ## Thanks

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,12 +1,12 @@
 FROM mitchty/alpine-ghc:latest
 MAINTAINER Dan Kubb <dkubb@fastmail.com>
 
-ENTRYPOINT ["/usr/local/sbin/build.sh"]
-CMD ["--help"]
-
 VOLUME /src
 WORKDIR /src
 
 RUN ["apk", "add", "--update-cache", "docker=1.6.2-r0"]
 
 COPY ["build.sh", "/usr/local/sbin/"]
+
+ENTRYPOINT ["/usr/local/sbin/build.sh"]
+CMD ["--help"]

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -7,9 +7,6 @@ CMD ["--help"]
 VOLUME /src
 WORKDIR /src
 
-RUN ["apk", "update"]
-RUN until apk add docker; do :; done
-
-RUN ["cabal", "update"]
+RUN ["apk", "add", "--update-cache", "docker=1.6.2-r0"]
 
 COPY ["build.sh", "/usr/local/sbin/"]

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,3 +1,4 @@
 FROM scratch
+EXPOSE 3000
 COPY ["build/hello/hello", "/usr/bin/"]
 ENTRYPOINT ["/usr/bin/hello"]

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,3 +1,3 @@
 FROM scratch
-COPY ["dist/build/hello/hello", "/usr/bin/"]
+COPY ["build/hello/hello", "/usr/bin/"]
 ENTRYPOINT ["/usr/bin/hello"]

--- a/example/Hello.hs
+++ b/example/Hello.hs
@@ -1,4 +1,15 @@
-import Prelude
+{-# LANGUAGE OverloadedStrings #-}
+
+import qualified Network.Wai              as Wai
+import qualified Network.Wai.Handler.Warp as Warp
+import qualified Network.HTTP.Types       as HTTP
+import           Prelude
 
 main :: IO ()
-main = putStrLn "Hello World"
+main = do
+    let port = 3000
+    putStrLn $ "Listening on port " ++ show port
+    Warp.run port app
+
+app :: Wai.Application
+app _req res = res $ Wai.responseLBS HTTP.status200 [] "Hello World!"

--- a/example/Setup.hs
+++ b/example/Setup.hs
@@ -1,2 +1,0 @@
-import Distribution.Simple
-main = defaultMain

--- a/example/hello.cabal
+++ b/example/hello.cabal
@@ -18,4 +18,7 @@ executable hello
                       -fwarn-implicit-prelude
     default-language: Haskell2010
     main-is:          Hello.hs
-    build-depends:    base >= 4 && < 5
+    build-depends:    base >= 4.8 && < 4.9,
+                      wai,
+                      warp,
+                      http-types

--- a/example/stack.yaml
+++ b/example/stack.yaml
@@ -1,0 +1,5 @@
+flags: {}
+packages:
+- '.'
+extra-deps: []
+resolver: nightly-2015-08-21

--- a/example/stack.yaml
+++ b/example/stack.yaml
@@ -1,5 +1,43 @@
-flags: {}
+flags:
+  text:
+    integer-simple: false
 packages:
 - '.'
-extra-deps: []
+extra-deps:
+- aeson-0.9.0.1
+- aeson-pretty-0.7.2
+- appar-0.1.4
+- attoparsec-0.13.0.1
+- auto-update-0.1.2.2
+- blaze-builder-0.4.0.1
+- byteorder-1.0.4
+- bytestring-builder-0.10.6.0.0
+- case-insensitive-1.2.0.4
+- cmdargs-0.10.13
+- dlist-0.7.1.1
+- hashable-1.2.3.3
+- hex-0.1.2
+- http-date-0.0.6.1
+- http-types-0.8.6
+- http2-1.0.2
+- iproute-1.5.0
+- mtl-2.2.1
+- mwc-random-0.13.3.2
+- network-2.6.2.1
+- primitive-0.6
+- random-1.1
+- scientific-0.3.3.8
+- simple-sendfile-0.2.21
+- stm-2.4.4
+- streaming-commons-0.1.12.1
+- syb-0.5.1
+- text-1.2.1.3
+- unix-compat-0.4.1.4
+- unordered-containers-0.2.5.1
+- vault-0.3.0.4
+- vector-0.11.0.0
+- wai-3.0.3.0
+- warp-3.1.1
+- word8-0.1.2
+- zlib-0.6.1.1
 resolver: nightly-2015-08-21


### PR DESCRIPTION
This branch changes the example application to be a simple WAI application.

I'm not yet sure if I will merge this into master as-is, or rename `example` to `examples` and have a few different example projects for building.
