### PR TITLE
Use stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 *.sw[op]
-/example/.cabal-sandbox/
-/example/cabal.sandbox.config
-/example/dist
+.stack-work
+/example/build

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ ENTRYPOINT ["/usr/bin/hello"]
 A project must include the following files:
 
 ```.
-├── project.cabal
-├── Setup.hs
+├── Dockerfile
+├── example.cabal
+├── stack.yaml
 └── ...
 ```
 

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,12 +1,12 @@
 FROM mitchty/alpine-ghc:latest
 MAINTAINER Dan Kubb <dkubb@fastmail.com>
 
-ENTRYPOINT ["/usr/local/sbin/build.sh"]
-CMD ["--help"]
-
 VOLUME /src
 WORKDIR /src
 
 RUN ["apk", "add", "--update-cache", "docker=1.6.2-r0"]
 
 COPY ["build.sh", "/usr/local/sbin/"]
+
+ENTRYPOINT ["/usr/local/sbin/build.sh"]
+CMD ["--help"]

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -7,9 +7,6 @@ CMD ["--help"]
 VOLUME /src
 WORKDIR /src
 
-RUN ["apk", "update"]
-RUN until apk add docker; do :; done
-
-RUN ["cabal", "update"]
+RUN ["apk", "add", "--update-cache", "docker=1.6.2-r0"]
 
 COPY ["build.sh", "/usr/local/sbin/"]

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,3 +1,3 @@
 FROM scratch
-COPY ["dist/build/hello/hello", "/usr/bin/"]
+COPY ["build/hello/hello", "/usr/bin/"]
 ENTRYPOINT ["/usr/bin/hello"]

--- a/example/Setup.hs
+++ b/example/Setup.hs
@@ -1,2 +1,0 @@
-import Distribution.Simple
-main = defaultMain

--- a/example/stack.yaml
+++ b/example/stack.yaml
@@ -1,0 +1,5 @@
+flags: {}
+packages:
+- '.'
+extra-deps: []
+resolver: nightly-2015-08-21


### PR DESCRIPTION
This branch changes the build process to use stack.

More testing will be required to prevent stack from using a downloaded ghc vs using the system provided ghc. We _always_ want to use the system provided ghc for musl.
